### PR TITLE
merge: (#7) 알림 구독 상태 명확화

### DIFF
--- a/src/application/domain/notification/model/notification.ts
+++ b/src/application/domain/notification/model/notification.ts
@@ -32,7 +32,7 @@ export class Notification {
 }
 
 export enum Topic {
-    NOTICE = 'notice',
-    ALLERGY = 'allergy',
-    COMMENT = 'comment'
+    NOTICE = 'NOTICE',
+    ALLERGY = 'ALLERGY',
+    COMMENT = 'COMMENT'
 }

--- a/src/application/domain/notification/usecase/toggle-all-subscriptions.usecase.ts
+++ b/src/application/domain/notification/usecase/toggle-all-subscriptions.usecase.ts
@@ -28,7 +28,7 @@ export class ToggleAllSubscriptionsUseCase {
                     deviceToken.id,
                     topic
                 );
-                return !!subscription;
+                return subscription ? subscription.isSubscribed : false;
             })
         ).then((results) => results.some((subscribed) => subscribed));
 

--- a/src/application/domain/notification/usecase/toggle-subscription.usecase.ts
+++ b/src/application/domain/notification/usecase/toggle-subscription.usecase.ts
@@ -27,7 +27,7 @@ export class ToggleSubscriptionUseCase {
             topic
         );
 
-        if (subscription) {
+        if (subscription && subscription.isSubscribed) {
             await this.fcmPort.unsubscribeTopic(deviceToken.token, topic);
             await this.topicSubscriptionPort.saveTopicSubscription({
                 deviceTokenId: deviceToken.id,


### PR DESCRIPTION
- 알림 구독 상태를 명확화 했습니다.
- 기존 코드에서는 구독 존재 여부만 확인 -> isSubscribed = false 일때 토글이 안됨

![image](https://github.com/user-attachments/assets/92c2a66f-20ac-43db-b30a-b789e039b22e)
![image](https://github.com/user-attachments/assets/7e81e37c-0b34-4156-b4ac-75e7e64eaffe)
