### PR TITLE
merge: (#17) usecase명 통일

### DIFF
--- a/src/application/domain/notification/usecase/query-all-notifications.usecase.ts
+++ b/src/application/domain/notification/usecase/query-all-notifications.usecase.ts
@@ -4,7 +4,7 @@ import { QueryNotificationsResponse, NotificationResponse } from '../dto/notific
 import { User } from '../../user/user';
 
 @Injectable()
-export class QueryNotificationsUseCase {
+export class QueryAllNotificationsUseCase {
     constructor(
         @Inject(NotificationPort)
         private readonly notificationPort: NotificationPort

--- a/src/infrastructure/domain/notification/presentation/notification.web.adapter.ts
+++ b/src/infrastructure/domain/notification/presentation/notification.web.adapter.ts
@@ -13,7 +13,7 @@ import {
 import { QueryTopicSubscriptionUseCase } from '../../../../application/domain/notification/usecase/query-topic-subscription.usecase';
 import { Topic } from '../../../../application/domain/notification/model/notification';
 import { ToggleAllSubscriptionsUseCase } from '../../../../application/domain/notification/usecase/toggle-all-subscriptions.usecase';
-import { QueryNotificationsUseCase } from '../../../../application/domain/notification/usecase/query-notifications.usecase';
+import { QueryAllNotificationsUseCase } from '../../../../application/domain/notification/usecase/query-all-notifications.usecase';
 import { ReadNotificationUseCase } from '../../../../application/domain/notification/usecase/read-notification.usecase';
 
 @Controller('notifications')
@@ -23,7 +23,7 @@ export class NotificationWebAdapter {
         private readonly toggleSubscriptionUseCase: ToggleSubscriptionUseCase,
         private readonly queryTopicSubscriptionUseCase: QueryTopicSubscriptionUseCase,
         private readonly toggleAllSubscriptionsUseCase: ToggleAllSubscriptionsUseCase,
-        private readonly queryNotificationsUseCase: QueryNotificationsUseCase,
+        private readonly queryAllNotificationsUseCase: QueryAllNotificationsUseCase,
         private readonly readNotificationUseCase: ReadNotificationUseCase
     ) {}
 
@@ -64,7 +64,7 @@ export class NotificationWebAdapter {
     @Permission([Authority.USER])
     @Get()
     async queryNotifications(@CurrentUser() user: User): Promise<QueryNotificationsResponse> {
-        return this.queryNotificationsUseCase.execute(user);
+        return this.queryAllNotificationsUseCase.execute(user);
     }
 
     @Permission([Authority.USER])

--- a/src/infrastructure/global/module/notification.module.ts
+++ b/src/infrastructure/global/module/notification.module.ts
@@ -29,7 +29,7 @@ import { FCMPort } from '../../../application/common/spi/fcm.spi';
 import { FCMAdapter } from '../../thirdparty/fcm/fcm.adapter';
 import { UserModule } from './user.module';
 import { AxiosModule } from './axios.module';
-import { QueryNotificationsUseCase } from '../../../application/domain/notification/usecase/query-notifications.usecase';
+import { QueryAllNotificationsUseCase } from '../../../application/domain/notification/usecase/query-all-notifications.usecase';
 import { ReadNotificationUseCase } from '../../../application/domain/notification/usecase/read-notification.usecase';
 
 const TOPIC_SUBSCRIPTION_PORT = {
@@ -63,7 +63,7 @@ const NOTIFICATION_PORT = { provide: NotificationPort, useClass: NotificationPer
         SetDeviceTokenUseCase,
         QueryTopicSubscriptionUseCase,
         ToggleAllSubscriptionsUseCase,
-        QueryNotificationsUseCase,
+        QueryAllNotificationsUseCase,
         ReadNotificationUseCase,
         FirebaseConfig,
         {


### PR DESCRIPTION
통일성 유지를 위해 네이밍을 수정했습니다.
query-notifications-usecase -> query-all-notifications-usecase